### PR TITLE
Remove the optional operator

### DIFF
--- a/lib/capybara-lockstep/helper.js
+++ b/lib/capybara-lockstep/helper.js
@@ -273,7 +273,7 @@ window.CapybaraLockstep = (function() {
       // Unpoly 0.x would wait one task after DOMContentLoaded before booting.
       // There's a slim chance that Capybara can observe the page before compilers have run.
       // Unpoly 1.0+ runs compilers on DOMContentLoaded, so there's no issue.
-      if (window.up?.version?.startsWith('0.')) {
+      if (window.up && window.up.version && window.up.startsWith('0.')) {
         startWork('Old Unpoly')
         setTimeout(function () {
           stopWork('Old Unpoly')


### PR DESCRIPTION
This gem is precisely what I needed to correct my flaky Capybara tests.
However, every time I ran it with the logger on, every other line said:
`Cannot synchronize: capybara-lockstep JavaScript snippet is missing`

When I used the following JavaScript error detection method I already included:
```
  def find_javascript_errors
    errors = page.driver.browser.logs.get(:browser)
    if errors.present?
      puts "-" * 30
      puts "Found #{errors.count} javascript #{'error'.pluralize(errors.count)}."
      puts "-" * 30
      errors.each do |error|
        puts "    #{error}"
      end
    end
    assert_equal 0, errors.count, "Found javascript errors"
  end
```
it found an issue with the snippet, an unrecognized '.' at 286:20 in my page code. 

I modified your snippet output `lib/capybara-lockstep/helper.js:276` and now it works for me without any error messages.
