### PR TITLE
Fix configuring logging to an existing logger object

### DIFF
--- a/lib/capybara-lockstep/configuration.rb
+++ b/lib/capybara-lockstep/configuration.rb
@@ -35,7 +35,7 @@ module Capybara
         end
 
         send_config_to_browser(<<~JS)
-          CapybaraLockstep.debug = #{value.to_json}
+          CapybaraLockstep.debug = #{debug?.to_json}
         JS
 
         @debug

--- a/lib/capybara-lockstep/logging.rb
+++ b/lib/capybara-lockstep/logging.rb
@@ -6,7 +6,7 @@ module Capybara
           message = "[capybara-lockstep] #{message}"
           if is_logger?(Lockstep.debug)
             # If someone set Capybara::Lockstep.debug to a logger, use that
-            Lockstep.debug(message)
+            Lockstep.debug.debug(message)
           else
             # Otherwise print to STDOUT
             puts message

--- a/spec/capybara-lockstep_spec.rb
+++ b/spec/capybara-lockstep_spec.rb
@@ -1,0 +1,16 @@
+describe Capybara::Lockstep do
+  describe ".debug" do
+    before { Capybara::Lockstep.debug = nil }
+    after { Capybara::Lockstep.debug = nil }
+
+    it "accepts true" do
+      expect {
+        Capybara::Lockstep.debug = true
+      }.to output(/STDOUT/).to_stdout
+    end
+
+    it "accepts a logger" do
+      Capybara::Lockstep.debug = Logger.new("/dev/null")
+    end
+  end
+end


### PR DESCRIPTION
The following code from the README would fail:

```ruby
Capybara::Lockstep.debug = Rails.logger
```