### PR TITLE
Support playwright driver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       activesupport (>= 4.2)
       capybara (>= 3.0)
       ruby2_keywords
-      selenium-webdriver (>= 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/capybara-lockstep.gemspec
+++ b/capybara-lockstep.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "capybara", ">= 3.0"
-  spec.add_dependency "selenium-webdriver", ">= 4.0"
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "ruby2_keywords"
 

--- a/lib/capybara-lockstep.rb
+++ b/lib/capybara-lockstep.rb
@@ -1,5 +1,11 @@
 require 'capybara'
-require 'selenium-webdriver'
+begin
+  require 'selenium-webdriver'
+  if Selenium::WebDriver::VERSION < '4.0.0'
+    raise "capybara-lockstep requires selenium-webdriver >= 4.0.0"
+  end
+rescue LoadError
+end
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/module/delegation'
 

--- a/lib/capybara-lockstep/capybara_ext.rb
+++ b/lib/capybara-lockstep/capybara_ext.rb
@@ -166,6 +166,7 @@ node_classes = [
   (Capybara::Selenium::SafariNode  if defined?(Capybara::Selenium::SafariNode)),
   (Capybara::Selenium::EdgeNode    if defined?(Capybara::Selenium::EdgeNode)),
   (Capybara::Selenium::IENode      if defined?(Capybara::Selenium::IENode)),
+  (Capybara::Playwright::Node      if defined?(Capybara::Playwright::Node)),
 ].compact
 
 if node_classes.empty?

--- a/lib/capybara-lockstep/page_access.rb
+++ b/lib/capybara-lockstep/page_access.rb
@@ -8,7 +8,7 @@ module Capybara
       delegate :evaluate_script, :evaluate_async_script, :execute_script, :driver, to: :page
 
       def javascript_driver?
-        driver.is_a?(Capybara::Selenium::Driver)
+        selenium_driver? || playwright_driver?
       end
 
       def alert_present?
@@ -17,10 +17,22 @@ module Capybara
         #
         # Apparently, while an alert/confirm is open, Chrome will block any requests
         # to its `getLog` API. This causes Selenium to time out with a `Net::ReadTimeout` error
+        return false unless selenium_driver?
+
         page.driver.browser.switch_to.alert
         true
       rescue Capybara::NotSupportedByDriverError, ::Selenium::WebDriver::Error::NoSuchAlertError, ::Selenium::WebDriver::Error::NoSuchWindowError
         false
+      end
+
+      private
+
+      def selenium_driver?
+        defined?(Capybara::Selenium::Driver) && driver.is_a?(Capybara::Selenium::Driver)
+      end
+
+      def playwright_driver?
+        defined?(Capybara::Playwright::Driver) && driver.is_a?(Capybara::Playwright::Driver)
       end
 
     end


### PR DESCRIPTION
The changes needed to support https://github.com/YusukeIwaki/capybara-playwright-driver were minimal.

I've removed selenium-webdriver as a runtime dependency, because projects using the playwright driver does not need to depend on it.

A version check will happen at runtime if selenium is available to ensure version 4 and up is in use.

Some improvements could possibly be made for projects that add capybara-lockstep, but does not have either selenium-webdriver or capybara-playwright-driver installed to encourage them to add one of them to their gemfile. Not sure if this could be indicated when adding/installing the gem or if it needs to happen at runtime.