### PR TITLE
Fix IntersectionObserver race condition in afterWaitTasks

### DIFF
--- a/lib/capybara-lockstep/helper.js
+++ b/lib/capybara-lockstep/helper.js
@@ -280,10 +280,20 @@ window.CapybaraLockstep = (function() {
 
   function afterWaitTasks(fn, waitTasks = defaultWaitTasks) {
     if (waitTasks > 0) {
-      // Wait 1 task and recurse
-      setTimeout(function() {
-        afterWaitTasks(fn, waitTasks - 1)
-      })
+      // Wait for a rendering frame to let rendering-triggered async work
+      // (e.g. IntersectionObserver callbacks) fire before checking idleness,
+      // then wait 1 macrotask and recurse.
+      let scheduleNext = function() {
+        setTimeout(function() {
+          afterWaitTasks(fn, waitTasks - 1)
+        })
+      }
+
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(scheduleNext)
+      } else {
+        scheduleNext()
+      }
     } else {
       fn()
     }


### PR DESCRIPTION
## Problem

`afterWaitTasks` uses `setTimeout` (macrotask) to schedule idle checks, but `IntersectionObserver` callbacks fire during the browser's rendering step. There is no guaranteed ordering between a macrotask and a rendering step, so lockstep sometimes declares idle before an `IntersectionObserver` triggers async work.

### Concrete scenario

After a click that reveals a lazy-loaded Turbo frame:

1. Click handlers fire → lockstep `startWork('click')` + Stimulus controller sets `display: block`
2. `stopWork('click')` → `afterWaitTasks(stopWorkNow, 1)` → `setTimeout(fn)` (macrotask)
3. Browser event loop decides whether to render:
   - **If rendering**: `IntersectionObserver` fires → Turbo `fetch()` starts → lockstep tracks it → idle check finds `jobCount > 0` → **test passes**
   - **If NO rendering** (browser skips at its discretion): `setTimeout` fires first → `stopWorkNow` → `jobCount = 0` → **lockstep declares idle** → test proceeds → `IntersectionObserver` fires later → **too late, test fails**

This causes ~30% flakiness in specs that click to reveal an element observed by `IntersectionObserver` (e.g. lazy Turbo frames in a sidebar).

## Solution

Add a `requestAnimationFrame` before each `setTimeout` hop in `afterWaitTasks`. Since rAF callbacks run right before rendering, and `IntersectionObserver` callbacks fire during rendering, this ensures rendering-triggered async work is picked up before the idle check.

Falls back to the previous `setTimeout`-only behavior when `requestAnimationFrame` is unavailable (e.g. non-browser environments).

## Testing

- All existing capybara-lockstep specs pass (45/45)
- The `'stays busy for the configured number of tasks'` test still works — the added rAF per hop is within timing tolerance
- Verified in a large Rails app (Turbo + Stimulus): a previously 30% flaky spec ("deleting task" in sidebar) passes consistently after this change